### PR TITLE
bugfix: when only Lua preread handler is present and content handler is

### DIFF
--- a/src/stream/ngx_stream_lua_request.c
+++ b/src/stream/ngx_stream_lua_request.c
@@ -15,6 +15,7 @@
 
 static ngx_int_t ngx_stream_lua_set_write_handler(ngx_stream_lua_request_t *r);
 static void ngx_stream_lua_writer(ngx_stream_lua_request_t *r);
+static void ngx_stream_lua_request_cleanup(void *data);
 
 
 ngx_stream_lua_cleanup_t *
@@ -71,11 +72,31 @@ ngx_stream_lua_cleanup_add(ngx_stream_lua_request_t *r, size_t size)
 }
 
 
+static void
+ngx_stream_lua_request_cleanup(void *data)
+{
+    ngx_stream_lua_request_t    *r = data;
+    ngx_stream_lua_cleanup_t    *cln;
+
+    cln = r->cleanup;
+    r->cleanup = NULL;
+
+    while (cln) {
+        if (cln->handler) {
+            cln->handler(cln->data);
+        }
+
+        cln = cln->next;
+    }
+}
+
+
 ngx_stream_lua_request_t *
 ngx_stream_lua_create_request(ngx_stream_session_t *s)
 {
-    ngx_pool_t               *pool;
-    ngx_stream_lua_request_t *r;
+    ngx_pool_t                  *pool;
+    ngx_stream_lua_request_t    *r;
+    ngx_pool_cleanup_t          *cln;
 
 #if 0
     pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, s->connection->log);
@@ -94,6 +115,14 @@ ngx_stream_lua_create_request(ngx_stream_session_t *s)
     r->connection = s->connection;
     r->session = s;
     r->pool = pool;
+
+    cln = ngx_pool_cleanup_add(pool, 0);
+    if (cln == NULL) {
+        return NULL;
+    }
+
+    cln->handler = ngx_stream_lua_request_cleanup;
+    cln->data = r;
 
     return r;
 }
@@ -180,7 +209,7 @@ ngx_stream_lua_finalize_real_request(ngx_stream_lua_request_t *r, ngx_int_t rc)
     }
 
     if (rc == NGX_DECLINED || rc == NGX_STREAM_INTERNAL_SERVER_ERROR) {
-        goto cleanup;
+        goto done;
     }
 
     if (rc == NGX_DONE) {
@@ -193,23 +222,13 @@ ngx_stream_lua_finalize_real_request(ngx_stream_lua_request_t *r, ngx_int_t rc)
 
     if (r->connection->buffered) {
         if (ngx_stream_lua_set_write_handler(r) != NGX_OK) {
-            goto cleanup;
+            goto done;
         }
 
         return;
     }
 
-cleanup:
-    cln = r->cleanup;
-    r->cleanup = NULL;
-
-    while (cln) {
-        if (cln->handler) {
-            cln->handler(cln->data);
-        }
-
-        cln = cln->next;
-    }
+done:
 
 #if 0
     pool = r->pool;

--- a/src/stream/ngx_stream_lua_request.c
+++ b/src/stream/ngx_stream_lua_request.c
@@ -193,7 +193,6 @@ ngx_stream_lua_block_reading(ngx_stream_lua_request_t *r)
 void
 ngx_stream_lua_finalize_real_request(ngx_stream_lua_request_t *r, ngx_int_t rc)
 {
-    ngx_stream_lua_cleanup_t  *cln;
 #if 0
     ngx_pool_t                *pool;
 #endif

--- a/src/subsystem/ngx_subsystem_lua_util.h.tt2
+++ b/src/subsystem/ngx_subsystem_lua_util.h.tt2
@@ -306,9 +306,9 @@ ngx_http_lua_create_ctx(ngx_http_request_t *r)
 ngx_stream_lua_create_ctx(ngx_stream_session_t *r)
 [% END %]
 {
-    lua_State                   *L;
+    lua_State                              *L;
     ngx_[% subsystem %]_lua_ctx_t          *ctx;
-    ngx_pool_cleanup_t          *cln;
+    ngx_pool_cleanup_t                     *cln;
     ngx_[% subsystem %]_lua_loc_conf_t     *llcf;
     ngx_[% subsystem %]_lua_main_conf_t    *lmcf;
 
@@ -355,13 +355,32 @@ ngx_stream_lua_create_ctx(ngx_stream_session_t *r)
 
         dd("lmcf: %p", lmcf);
 
-[% IF subsystem == 'http' %]
+[% IF subsystem == 'http' -%]
         L = ngx_http_lua_init_vm(lmcf->lua, lmcf->cycle, r->pool, lmcf,
                                  r->connection->log, &cln);
-[% ELSIF subsystem == 'stream' %]
+
+[% ELSIF subsystem == 'stream' -%]
+        /*
+         * caveats: we need to move the vm cleanup hook to the list end
+         * to ensure it will be executed *after* the request cleanup
+         * hook registered by ngx_stream_lua_create_request to preserve
+         * the correct semantics.
+         */
+
         L = ngx_stream_lua_init_vm(lmcf->lua, lmcf->cycle, sreq->pool, lmcf,
                                    r->connection->log, &cln);
-[% END %]
+
+        while (cln->next != NULL) {
+            cln = cln->next;
+        }
+
+        cln->next = sreq->pool->cleanup;
+
+        cln = sreq->pool->cleanup;
+        sreq->pool->cleanup = cln->next;
+        cln->next = NULL;
+[% END -%]
+
         if (L == NULL) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "failed to initialize Lua VM");


### PR DESCRIPTION
non-Lua, cleanup hooks will be incorrectly skipped.