### PR TITLE
Added Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: perl
+sudo: false
+dist: trusty
+
+os: linux
+
+addons:
+  apt:
+    packages:
+      - ack-grep
+
+env:
+  matrix:
+    - SUBSYS=http
+    - SUBSYS=stream
+
+install:
+  - git clone https://github.com/openresty/openresty-devel-utils.git
+
+script:
+  - export PATH=$PWD/openresty-devel-utils:$PATH
+  - ln -s `which ack-grep` $PWD/openresty-devel-utils/ack
+  - make -j`nproc`
+  - ngx-releng build/src

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/openresty/meta-lua-nginx-module.svg?branch=master)](https://travis-ci.org/openresty/meta-lua-nginx-module)
+
 # Name
 
 meta-lua-nginx-module - templates and toolchains for generating


### PR DESCRIPTION
Now we can test build and `ngx-relang` built fines in less than 1 minute using Travis thanks to the fast spawn time of the container based builder.