### PR TITLE
bugfix: checked function call indentation in macro.

### DIFF
--- a/src/subsys/ddebug.h.tt2
+++ b/src/subsys/ddebug.h.tt2
@@ -56,21 +56,21 @@ dd(const char *fmt, ...) {
 
 #define dd_check_read_event_handler(r)                                       \
     dd("r->read_event_handler = %s",                                         \
-        r->read_event_handler == ngx_http_block_reading ?                    \
-            "ngx_http_block_reading" :                                       \
-        r->read_event_handler == ngx_http_test_reading ?                     \
-            "ngx_http_test_reading" :                                        \
-        r->read_event_handler == ngx_http_request_empty_handler ?            \
-            "ngx_http_request_empty_handler" : "UNKNOWN")
+       r->read_event_handler == ngx_http_block_reading ?                     \
+       "ngx_http_block_reading" :                                            \
+       r->read_event_handler == ngx_http_test_reading ?                      \
+       "ngx_http_test_reading" :                                             \
+       r->read_event_handler == ngx_http_request_empty_handler ?             \
+       "ngx_http_request_empty_handler" : "UNKNOWN")
 
 #define dd_check_write_event_handler(r)                                      \
     dd("r->write_event_handler = %s",                                        \
-        r->write_event_handler == ngx_http_handler ?                         \
-            "ngx_http_handler" :                                             \
-        r->write_event_handler == ngx_http_core_run_phases ?                 \
-            "ngx_http_core_run_phases" :                                     \
-        r->write_event_handler == ngx_http_request_empty_handler ?           \
-            "ngx_http_request_empty_handler" : "UNKNOWN")
+       r->write_event_handler == ngx_http_handler ?                          \
+       "ngx_http_handler" :                                                  \
+       r->write_event_handler == ngx_http_core_run_phases ?                  \
+       "ngx_http_core_run_phases" :                                          \
+       r->write_event_handler == ngx_http_request_empty_handler ?            \
+       "ngx_http_request_empty_handler" : "UNKNOWN")
 
 #else
 

--- a/src/subsys/ngx_subsys_lua_probe.h.tt2
+++ b/src/subsys/ngx_subsys_lua_probe.h.tt2
@@ -49,7 +49,8 @@
     NGINX_LUA_HTTP_LUA_SOCKET_TCP_RECEIVE_DONE(r, u, data, len)
 
 #define ngx_[% subsys %]_lua_probe_socket_tcp_setkeepalive_buf_unread(r, u,  \
-                                                                 data, len)  \
+                                                                      data,  \
+                                                                      len)   \
     NGINX_LUA_HTTP_LUA_SOCKET_TCP_SETKEEPALIVE_BUF_UNREAD(r, u, data, len)
 
 #define ngx_[% subsys %]_lua_probe_user_thread_spawn(r, creator, newthread)  \

--- a/util/mini-tt2.pl
+++ b/util/mini-tt2.pl
@@ -467,7 +467,7 @@ while (<$in>) {
                 my $len = length $prefix;
                 if ($raw_line =~ /^ (.*? \w \( ) /x) {
                     my $raw_len = length $1;
-                    if ($prefix !~ m{^ (?: \# \s*(?!:define) | \s* /\* )}x) {
+                    if ($prefix !~ m{^ (?: \# \s*(?!define) | \s* /\* )}x) {
                         #warn "line $.: found continued func call: $_";
                         $continued_func_call = $.;
                         $func_prefix_len_diff = $raw_len - $len;


### PR DESCRIPTION
Current implementation won't indent function call in the macro, and
output something like this:

 #define ngx_stream_lua_regex_exec(re, e, s, start, captures, size,           \
                                         opts)                                \

This commit fixed it by applying the indentation in macro.