### PR TITLE
mini-tt2: output warning at the beginning of the file to remind

### DIFF
--- a/util/mini-tt2.pl
+++ b/util/mini-tt2.pl
@@ -98,6 +98,17 @@ my ($func_raw_prefix_len);
 my ($in_if, $in_else, $if_branch_hit);
 my ($in_block, $block, %blocks);
 my (%ctl_cmds, $prev_continuing_macro_line);
+my $modified = localtime((stat($infile))[9]);
+
+print $out <<"EOF";
+/*
+ * !!! DO NOT EDIT DIRECTLY !!!
+ * This file was automatically generated from the following template:
+ *
+ * File: $infile
+ * Modified: $modified
+ */
+EOF
 
 while (<$in>) {
     if (/\s+\n$/) {


### PR DESCRIPTION
developers not to edit it directly.

Here is what it looks like:

```shell
[datong@localhost meta-lua-nginx-module]$ head build/src/ngx_stream_lua_util.h 
/*
 * !!! DO NOT EDIT DIRECTLY !!!
 * This file was automatically generated from the following template:
 *
 * File: src/subsys/ngx_subsys_lua_util.h.tt2
 * Modified: Mon Mar 26 12:16:25 2018
 */
```