### PR TITLE
version: we now require at least NGINX 1.13.6 to build stream_lua. also

### DIFF
--- a/src/subsys/api/ngx_subsys_lua_api.h.tt2
+++ b/src/subsys/api/ngx_subsys_lua_api.h.tt2
@@ -24,7 +24,11 @@
 /* Public API for other Nginx modules */
 
 
-#define ngx_[% subsys %]_lua_version  10012
+[% IF http_subsys %]
+#define ngx_http_lua_version    10012
+[% ELSIF stream_subsys %]
+#define ngx_stream_lua_version  4
+[% END %]
 
 
 typedef struct {

--- a/src/subsys/ngx_subsys_lua_common.h.tt2
+++ b/src/subsys/ngx_subsys_lua_common.h.tt2
@@ -47,8 +47,13 @@
 #endif
 
 
+[% IF http_subsys %]
 #if !defined(nginx_version) || (nginx_version < 1006000)
 #error at least nginx 1.6.0 is required but found an older version
+[% ELSIF stream_subsys %]
+#if !defined(nginx_version) || (nginx_version < 1013006)
+#error at least nginx 1.13.6 is required but found an older version
+[% END %]
 #endif
 
 


### PR DESCRIPTION
fixed API version number. closes #38. closes #39.