### PR TITLE
misc: updated _G write guard message to be more accurate.

### DIFF
--- a/src/subsys/ngx_subsys_lua_util.c.tt2
+++ b/src/subsys/ngx_subsys_lua_util.c.tt2
@@ -819,7 +819,7 @@ ngx_[% subsys %]_lua_inject_ngx_api(lua_State *L, ngx_[% subsys %]_lua_main_conf
         const char buf[] =
             "local ngx_log = ngx.log\n"
             "local ngx_WARN = ngx.WARN\n"
-            "local type = type\n"
+            "local tostring = tostring\n"
             "local ngx_get_phase = ngx.get_phase\n"
             "local traceback = require 'debug'.traceback\n"
             "local function newindex(table, key, value)\n"
@@ -828,9 +828,11 @@ ngx_[% subsys %]_lua_inject_ngx_api(lua_State *L, ngx_[% subsys %]_lua_main_conf
                 "if phase == 'init_worker' or phase == 'init' then\n"
                     "return\n"
                 "end\n"
-                "ngx_log(ngx_WARN, '[% subsys %] lua attempting to write to the "
-                         "lua global variable \\'', tostring(key), "
-                         "'\\'\\n', traceback())\n"
+                "ngx_log(ngx_WARN, 'writing a global lua variable "
+                         "(\\'', tostring(key), '\\') which may lead to "
+                         "race conditions between concurrent requests, so "
+                         "prefer the use of \\'local\\' variables', "
+                         "traceback('', 2))\n"
             "end\n"
             "setmetatable(_G, { __newindex = newindex })\n"
             ;
@@ -839,8 +841,8 @@ ngx_[% subsys %]_lua_inject_ngx_api(lua_State *L, ngx_[% subsys %]_lua_main_conf
 
         if (rc != 0) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "failed to load Lua code for the _G write guard: ",
-                          "%i: %s", rc, lua_tostring(L, -1));
+                          "failed to load Lua code (%i): %s",
+                          rc, lua_tostring(L, -1));
 
             lua_pop(L, 1);
             return;
@@ -849,7 +851,7 @@ ngx_[% subsys %]_lua_inject_ngx_api(lua_State *L, ngx_[% subsys %]_lua_main_conf
         rc = lua_pcall(L, 0, 0, 0);
         if (rc != 0) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "failed to run Lua code for the _G write guard: %s",
+                          "failed to run Lua code (%i): %s",
                           rc, lua_tostring(L, -1));
             lua_pop(L, 1);
         }


### PR DESCRIPTION
* more appropriate message ("writing" instead of "attempting to")
* remove http/lua prefix (`ngx.log` will inject `[lua]` and `stream [lua]`
  already)
* remove unused cached global
* cache `tostring` global locally