### PR TITLE
change: we now print an alert when a non openresty-specific version of

### DIFF
--- a/src/subsys/ngx_subsys_lua_module.c.tt2
+++ b/src/subsys/ngx_subsys_lua_module.c.tt2
@@ -894,6 +894,19 @@ ngx_[% subsys %]_lua_init(ngx_conf_t *cf)
     if (lmcf->lua == NULL) {
         dd("initializing lua vm");
 
+#ifndef OPENRESTY_LUAJIT
+        if (ngx_process != NGX_PROCESS_SIGNALLER && !ngx_test_config) {
+            ngx_log_error(NGX_LOG_ALERT, cf->log, 0,
+                          "detected a LuaJIT version which is not OpenResty's"
+                          "; many optimizations will be disabled and "
+                          "performance will be compromised (see "
+                          "https://github.com/openresty/luajit2 for "
+                          "OpenResty's LuaJIT or, even better, consider using "
+                          "the OpenResty releases from https://openresty.org/"
+                          "en/download.html)");
+        }
+#endif
+
 [% IF http_subsys %]
         ngx_[% subsys %]_lua_content_length_hash =
                                   ngx_[% subsys %]_lua_hash_literal("content-length");


### PR DESCRIPTION
luajit is detected since many optimizations would be missing.

Sister PRs:
* https://github.com/openresty/lua-nginx-module/pull/1411
* https://github.com/openresty/stream-lua-nginx-module/pull/137