### PR TITLE
feature: Expose req_time API in stream module

### DIFF
--- a/src/subsys/ngx_subsys_lua_util.c.tt2
+++ b/src/subsys/ngx_subsys_lua_util.c.tt2
@@ -2343,13 +2343,13 @@ ngx_[% subsys %]_lua_inject_req_api(ngx_log_t *log, lua_State *L)
     lua_pushcfunction(L, ngx_[% subsys %]_lua_req_socket);
     lua_setfield(L, -2, "socket");
 
+    ngx_[% subsys %]_lua_inject_req_time_api(L);
 [% IF http_subsys %]
     ngx_[% subsys %]_lua_inject_req_header_api(L);
     ngx_[% subsys %]_lua_inject_req_uri_api(log, L);
     ngx_[% subsys %]_lua_inject_req_args_api(L);
     ngx_[% subsys %]_lua_inject_req_body_api(L);
     ngx_[% subsys %]_lua_inject_req_method_api(L);
-    ngx_[% subsys %]_lua_inject_req_time_api(L);
     ngx_[% subsys %]_lua_inject_req_misc_api(L);
 [% END %]
 


### PR DESCRIPTION
Originally part of https://github.com/openresty/stream-lua-nginx-module/pull/122/commits/a6afd31d32b31cf67afb13873deefb0c9d4e50a9