### PR TITLE
feature: turn on FFI API for stream module

### DIFF
--- a/src/subsys/ngx_subsys_lua_common.h.tt2
+++ b/src/subsys/ngx_subsys_lua_common.h.tt2
@@ -9,13 +9,6 @@
 #define _NGX_[% SUBSYS %]_LUA_COMMON_H_INCLUDED_
 
 
-[% IF stream_subsys %]
-#ifndef NGX_LUA_NO_FFI_API
-#define NGX_LUA_NO_FFI_API
-#endif
-[% END %]
-
-
 #include <nginx.h>
 #include <ngx_core.h>
 #include <ngx_[% subsys %].h>

--- a/src/subsys/ngx_subsys_lua_control.c.tt2
+++ b/src/subsys/ngx_subsys_lua_control.c.tt2
@@ -489,24 +489,31 @@ ngx_[% subsys %]_lua_ffi_exit([% req_type %] *r, int status, u_char *err,
         return NGX_ERROR;
     }
 
-    if (ngx_[% subsys %]_lua_ffi_check_context(ctx, NGX_[% SUBSYS %]_LUA_CONTEXT_REWRITE
-                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_ACCESS
-                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_CONTENT
+    if (ngx_[% subsys %]_lua_ffi_check_context(ctx, NGX_[% SUBSYS %]_LUA_CONTEXT_CONTENT
                                                | NGX_[% SUBSYS %]_LUA_CONTEXT_TIMER
-                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_HEADER_FILTER
                                                | NGX_[% SUBSYS %]_LUA_CONTEXT_BALANCER
                                                | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_CERT
+[% IF http_subsys %]
+                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_REWRITE
+                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_ACCESS
+                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_HEADER_FILTER
                                                | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_STORE
-                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_FETCH,
-                                               err, errlen)
+                                               | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_FETCH
+[% ELSIF stream_subsys %]
+                                               | NGX_STREAM_LUA_CONTEXT_PREREAD
+[% END %]
+                                               , err, errlen)
         != NGX_OK)
     {
         return NGX_ERROR;
     }
 
     if (ctx->context & (NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_CERT
+[% IF http_subsys %]
                         | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_STORE
-                        | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_FETCH))
+                        | NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_FETCH
+[% END %]
+                       ))
     {
 
 #if (NGX_[% SUBSYS %]_SSL)
@@ -517,9 +524,11 @@ ngx_[% subsys %]_lua_ffi_exit([% req_type %] *r, int status, u_char *err,
         ngx_log_debug1(NGX_LOG_DEBUG_[% SUBSYS %], r->connection->log, 0,
                        "lua exit with code %d", status);
 
+[% IF http_subsys %]
         if (ctx->context == NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_SESS_STORE) {
             return NGX_DONE;
         }
+[% END %]
 
         return NGX_OK;
 
@@ -566,8 +575,11 @@ ngx_[% subsys %]_lua_ffi_exit([% req_type %] *r, int status, u_char *err,
     ngx_log_debug1(NGX_LOG_DEBUG_[% SUBSYS %], r->connection->log, 0,
                    "lua exit with code %i", ctx->exit_code);
 
-    if (ctx->context & (NGX_[% SUBSYS %]_LUA_CONTEXT_HEADER_FILTER
-                        | NGX_[% SUBSYS %]_LUA_CONTEXT_BALANCER))
+    if (ctx->context & (NGX_[% SUBSYS %]_LUA_CONTEXT_BALANCER
+[% IF http_subsys %]
+                        | NGX_[% SUBSYS %]_LUA_CONTEXT_HEADER_FILTER
+[% END %]
+                       ))
     {
         return NGX_DONE;
     }

--- a/src/subsys/ngx_subsys_lua_variable.c.tt2
+++ b/src/subsys/ngx_subsys_lua_variable.c.tt2
@@ -317,11 +317,13 @@ ngx_[% subsys %]_lua_ffi_var_get([% req_type %] *r, u_char *name_data,
 {
     ngx_uint_t                   hash;
     ngx_str_t                    name;
+[% IF http_subsys %]
 #if (NGX_PCRE)
     u_char                      *p;
     ngx_uint_t                   n;
     int                         *cap;
 #endif
+[% END %]
 
     ngx_[% subsys %]_variable_value_t   *vv;
 
@@ -335,6 +337,7 @@ ngx_[% subsys %]_lua_ffi_var_get([% req_type %] *r, u_char *name_data,
         return NGX_ERROR;
     }
 
+[% IF http_subsys %]
 #if (NGX_PCRE)
     if (name_data == 0) {
         if (capture_id <= 0) {
@@ -365,6 +368,7 @@ ngx_[% subsys %]_lua_ffi_var_get([% req_type %] *r, u_char *name_data,
         return NGX_OK;
     }
 #endif
+[% END %]
 
     hash = ngx_hash_strlow(lowcase_buf, name_data, name_len);
 
@@ -474,12 +478,20 @@ ngx_[% subsys %]_lua_ffi_var_set([% req_type %] *r, u_char *name_data,
                 vv->len = value_len;
             }
 
+[% IF http_subsys %]
             v->set_handler(r, vv, v->data);
+[% ELSIF stream_subsys %]
+            v->set_handler(r->session, vv, v->data);
+[% END %]
             return NGX_OK;
         }
 
         if (v->flags & NGX_[% SUBSYS %]_VAR_INDEXED) {
+[% IF http_subsys %]
             vv = &r->variables[v->index];
+[% ELSIF stream_subsys %]
+            vv = &r->session->variables[v->index];
+[% END %]
 
             dd("set indexed variable");
 


### PR DESCRIPTION
Originally part of https://github.com/openresty/stream-lua-nginx-module/pull/122

This PR removes the limitations that force us to use `NGX_LUA_NO_FFI_API` in the stream module.