### PR TITLE
synchronized with lua-nginx-module #fbb8919.

### DIFF
--- a/src/http/ngx_http_lua_headers_out.c
+++ b/src/http/ngx_http_lua_headers_out.c
@@ -476,8 +476,8 @@ ngx_http_clear_builtin_header(ngx_http_request_t *r,
 
 
 ngx_int_t
-ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_str_t key,
-    ngx_str_t value, unsigned override)
+ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx,
+    ngx_str_t key, ngx_str_t value, unsigned override)
 {
     ngx_http_lua_header_val_t         hv;
     ngx_http_lua_set_header_t        *handlers = ngx_http_lua_set_handlers;
@@ -508,6 +508,10 @@ ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_str_t key,
         hv.offset = handlers[i].offset;
         hv.handler = handlers[i].handler;
 
+        if (hv.handler == ngx_http_set_content_type_header) {
+            ctx->mime_set = 1;
+        }
+
         break;
     }
 
@@ -528,7 +532,7 @@ ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_str_t key,
 
 int
 ngx_http_lua_get_output_header(lua_State *L, ngx_http_request_t *r,
-    ngx_str_t *key)
+    ngx_http_lua_ctx_t *ctx, ngx_str_t *key)
 {
     ngx_table_elt_t            *h;
     ngx_list_part_t            *part;
@@ -550,8 +554,8 @@ ngx_http_lua_get_output_header(lua_State *L, ngx_http_request_t *r,
         break;
 
     case 12:
-        if (r->headers_out.content_type.len
-            && ngx_strncasecmp(key->data, (u_char *) "Content-Type", 12) == 0)
+        if (ngx_strncasecmp(key->data, (u_char *) "Content-Type", 12) == 0
+            && r->headers_out.content_type.len)
         {
             lua_pushlstring(L, (char *) r->headers_out.content_type.data,
                             r->headers_out.content_type.len);

--- a/src/http/ngx_http_lua_headers_out.h
+++ b/src/http/ngx_http_lua_headers_out.h
@@ -12,10 +12,10 @@
 #include "ngx_http_lua_common.h"
 
 
-ngx_int_t ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_str_t key,
-    ngx_str_t value, unsigned override);
+ngx_int_t ngx_http_lua_set_output_header(ngx_http_request_t *r,
+    ngx_http_lua_ctx_t *ctx, ngx_str_t key, ngx_str_t value, unsigned override);
 int ngx_http_lua_get_output_header(lua_State *L, ngx_http_request_t *r,
-    ngx_str_t *key);
+    ngx_http_lua_ctx_t *ctx, ngx_str_t *key);
 
 
 #endif /* _NGX_HTTP_LUA_HEADERS_OUT_H_INCLUDED_ */

--- a/src/http/ngx_http_lua_subrequest.c
+++ b/src/http/ngx_http_lua_subrequest.c
@@ -1031,6 +1031,14 @@ ngx_http_lua_post_subrequest(ngx_http_request_t *r, void *data, ngx_int_t rc)
     dd("pr_coctx status: %d", (int) pr_coctx->sr_statuses[ctx->index]);
 
     /* copy subrequest response headers */
+    if (ctx->headers_set) {
+        rc = ngx_http_lua_set_content_type(r, ctx);
+        if (rc != NGX_OK) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "failed to set default content type: %i", rc);
+            return NGX_ERROR;
+        }
+    }
 
     pr_coctx->sr_headers[ctx->index] = &r->headers_out;
 

--- a/src/subsys/ngx_subsys_lua_common.h.tt2
+++ b/src/subsys/ngx_subsys_lua_common.h.tt2
@@ -704,6 +704,10 @@ typedef struct ngx_[% subsys %]_lua_ctx_s {
 
     unsigned         headers_set:1; /* whether the user has set custom
                                        response headers */
+[% IF http_subsys %]
+    unsigned         mime_set:1;    /* whether the user has set Content-Type
+                                       response header */
+[% END %]
 
 [% IF http_subsys %]
     unsigned         entered_rewrite_phase:1;

--- a/src/subsys/ngx_subsys_lua_util.c.tt2
+++ b/src/subsys/ngx_subsys_lua_util.c.tt2
@@ -442,7 +442,9 @@ ngx_[% subsys %]_lua_send_header_if_needed([% req_type %] *r,
             r->headers_out.status = NGX_HTTP_OK;
         }
 
-        if (!ctx->headers_set && ngx_[% subsys %]_lua_set_content_type(r) != NGX_OK) {
+        if (!ctx->mime_set
+            && ngx_[% subsys %]_lua_set_content_type(r, ctx) != NGX_OK)
+        {
             return NGX_ERROR;
         }
 

--- a/src/subsys/ngx_subsys_lua_util.h.tt2
+++ b/src/subsys/ngx_subsys_lua_util.h.tt2
@@ -514,9 +514,12 @@ ngx_[% subsys %]_lua_hash_str(u_char *src, size_t n)
 
 [% IF http_subsys %]
 static ngx_inline ngx_int_t
-ngx_[% subsys %]_lua_set_content_type([% req_type %] *r)
+ngx_[% subsys %]_lua_set_content_type([% req_type %] *r,
+    ngx_[% subsys %]_lua_ctx_t *ctx)
 {
     ngx_[% subsys %]_lua_loc_conf_t     *llcf;
+
+    ctx->mime_set = 1;
 
     llcf = ngx_[% req_subsys %]_get_module_loc_conf(r, ngx_[% subsys %]_lua_module);
     if (llcf->use_default_type


### PR DESCRIPTION
change: we now avoid generating the Content-Type response header when getting all response headers. #fbb8919
bugfix: ensured Content-Type header gets generated when other headers get set. #cec2a09
bugfix: we now avoid generating a Content-Type header when getting/setting other response headers. #017e004