### PR TITLE
bugfix: fixed a segfault introduced in c04bc97 when testing an nginx configuration containing 'lua_shared_dict' directive(s).

### DIFF
--- a/src/subsys/ngx_subsys_lua_api.c.tt2
+++ b/src/subsys/ngx_subsys_lua_api.c.tt2
@@ -197,7 +197,7 @@ ngx_[% subsys %]_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
     lmcf->shm_zones_inited++;
 
     if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
-        && lmcf->init_handler)
+        && lmcf->init_handler && !ngx_test_config)
     {
         saved_cycle = ngx_cycle;
         ngx_cycle = ctx->cycle;


### PR DESCRIPTION
Port of https://github.com/openresty/lua-nginx-module/pull/1463

In commit c04bc97, we avoided running `init_by_lua*` in signaller processes and
when testing the Nginx configuration. However, when the Nginx configuration
contains `lua_shared_dict` directives, the execution of `init_by_lua*` will be
post-poned when testing the configuration.

This case was not handled and led to the segmentation fault reported in
openresty/lua-nginx-module#1462.

Co-authored-by: spacewander <spacewanderlzx@gmail.com>