### PR TITLE
feature: include `ngx_stream_lua_request.h` in `ngx_stream_lua_api.h` to

### DIFF
--- a/src/subsys/api/ngx_subsys_lua_api.h.tt2
+++ b/src/subsys/api/ngx_subsys_lua_api.h.tt2
@@ -16,6 +16,11 @@
 #include <ngx_http.h>
 [% END %]
 
+[% IF stream_subsys %]
+#include <ngx_stream.h>
+#include "../ngx_stream_lua_request.h"
+[% END %]
+
 
 #include <lua.h>
 #include <stdint.h>


### PR DESCRIPTION
ensure:

1. The `ngx_stream_lua_request_t` is accessible by third party C modules
and
2. Helper macros (such as `ngx_stream_lua_get_module_ctx`) are
accessible by party C modules