### PR TITLE
feature: add FFI interface to verify SSL client certificate

### DIFF
--- a/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
+++ b/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
@@ -1369,6 +1369,7 @@ int
 ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
     void *cdata, int depth, char **err)
 {
+    ngx_[% subsys %]_lua_ctx_t      *ctx;
     ngx_ssl_conn_t                  *ssl_conn;
 [% IF http_subsys %]
     ngx_http_ssl_srv_conf_t         *sscf;
@@ -1385,6 +1386,21 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
 #else
     int                             i;
 #endif
+
+[% IF http_subsys %]
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+[% ELSIF stream_subsys %]
+    ctx = ngx_stream_get_module_ctx(r->session, ngx_stream_lua_module);
+[% END %]
+    if (ctx == NULL) {
+        *err = "no request ctx found";
+        return NGX_ERROR;
+    }
+
+    if (!(ctx->context & NGX_[% SUBSYS %]_LUA_CONTEXT_SSL_CERT)) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
         *err = "bad request";

--- a/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
+++ b/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
@@ -1352,4 +1352,104 @@ failed:
 }
 
 
+static int
+ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+{
+    /*
+     * we never terminate handshake here and user can later use
+     * $ssl_client_verify to check verification result.
+     *
+     * this is consistent with Nginx behavior.
+     */
+    return 1;
+}
+
+
+int
+ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
+    int depth,
+    void *cdata, char **err)
+{
+    ngx_ssl_conn_t         *ssl_conn;
+    STACK_OF(X509)         *chain = cdata;
+    STACK_OF(X509_NAME)    *name_chain = NULL;
+    X509                   *x509 = NULL;
+    X509_NAME              *subject = NULL;
+    X509_STORE             *ca_store = NULL;
+#ifdef OPENSSL_IS_BORINGSSL
+    size_t                 i;
+#else
+    int                    i;
+#endif
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
+    if (ca_store == NULL) {
+        *err = "SSL_CTX_get_cert_store() failed";
+        return NGX_ERROR;
+    }
+
+    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+
+    SSL_set_verify_depth(ssl_conn, depth);
+
+    if (chain != NULL) {
+        /* construct name chain */
+
+        name_chain = sk_X509_NAME_new_null();
+        if (name_chain == NULL) {
+            *err = "sk_X509_NAME_new_null() failed";
+            return NGX_ERROR;
+        }
+
+        for (i = 0; i < sk_X509_num(chain); i++) {
+            x509 = sk_X509_value(chain, i);
+            if (x509 == NULL) {
+                *err = "sk_X509_value() failed";
+                goto failed;
+            }
+
+            /* add subject to name chain, which will be sent to client */
+            subject = X509_NAME_dup(X509_get_subject_name(x509));
+            if (subject == NULL) {
+                *err = "X509_get_subject_name() failed";
+                goto failed;
+            }
+
+            if (!sk_X509_NAME_push(name_chain, subject)) {
+                *err = "sk_X509_NAME_push() failed";
+                X509_NAME_free(subject);
+                goto failed;
+            }
+
+            /* add to trusted CA store */
+            if (X509_STORE_add_cert(ca_store, x509) == 0) {
+                *err = "X509_STORE_add_cert() failed";
+                goto failed;
+            }
+        }
+
+        SSL_set_client_CA_list(ssl_conn, name_chain);
+    }
+
+    return NGX_OK;
+
+failed:
+
+    sk_X509_NAME_free(name_chain);
+
+    return NGX_ERROR;
+}
+
+
 #endif /* NGX_[% SUBSYS %]_SSL */

--- a/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
+++ b/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
@@ -1367,19 +1367,23 @@ ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 
 int
 ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
-    int depth,
-    void *cdata, char **err)
+    void *cdata, int depth, char **err)
 {
-    ngx_ssl_conn_t         *ssl_conn;
-    STACK_OF(X509)         *chain = cdata;
-    STACK_OF(X509_NAME)    *name_chain = NULL;
-    X509                   *x509 = NULL;
-    X509_NAME              *subject = NULL;
-    X509_STORE             *ca_store = NULL;
+    ngx_ssl_conn_t                  *ssl_conn;
+[% IF http_subsys %]
+    ngx_http_ssl_srv_conf_t         *sscf;
+[% ELSIF stream_subsys %]
+    ngx_stream_ssl_conf_t           *sscf;
+[% END %]
+    STACK_OF(X509)                  *chain = cdata;
+    STACK_OF(X509_NAME)             *name_chain = NULL;
+    X509                            *x509 = NULL;
+    X509_NAME                       *subject = NULL;
+    X509_STORE                      *ca_store = NULL;
 #ifdef OPENSSL_IS_BORINGSSL
-    size_t                 i;
+    size_t                          i;
 #else
-    int                    i;
+    int                             i;
 #endif
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
@@ -1393,17 +1397,33 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
         return NGX_ERROR;
     }
 
-    ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
-    if (ca_store == NULL) {
-        *err = "SSL_CTX_get_cert_store() failed";
-        return NGX_ERROR;
-    }
+    /* enable verify */
 
     SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
 
+    /* set depth */
+
+    if (depth < 0) {
+[% IF http_subsys %]
+        sscf = ngx_http_get_module_srv_conf(r,
+            ngx_http_ssl_module);
+[% ELSIF stream_subsys %]
+        sscf = ngx_stream_get_module_srv_conf(r->session,
+            ngx_stream_ssl_module);
+[% END %]
+        if (sscf != NULL) {
+            depth = sscf->verify_depth;
+        }
+    }
     SSL_set_verify_depth(ssl_conn, depth);
 
     if (chain != NULL) {
+        ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
+        if (ca_store == NULL) {
+            *err = "SSL_CTX_get_cert_store() failed";
+            return NGX_ERROR;
+        }
+
         /* construct name chain */
 
         name_chain = sk_X509_NAME_new_null();

--- a/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
+++ b/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
@@ -1413,6 +1413,9 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
 [% END %]
         if (sscf != NULL) {
             depth = sscf->verify_depth;
+        } else {
+            /* same as the default value of ssl_verify_depth */
+            depth = 1;
         }
     }
     SSL_set_verify_depth(ssl_conn, depth);

--- a/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
+++ b/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
@@ -1437,9 +1437,9 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
     SSL_set_verify_depth(ssl_conn, depth);
 
     if (chain != NULL) {
-        ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
+        ca_store = X509_STORE_new();
         if (ca_store == NULL) {
-            *err = "SSL_CTX_get_cert_store() failed";
+            *err = "X509_STORE_new() failed";
             return NGX_ERROR;
         }
 
@@ -1448,7 +1448,7 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
         name_chain = sk_X509_NAME_new_null();
         if (name_chain == NULL) {
             *err = "sk_X509_NAME_new_null() failed";
-            return NGX_ERROR;
+            goto failed;
         }
 
         for (i = 0; i < sk_X509_num(chain); i++) {
@@ -1478,12 +1478,19 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
             }
         }
 
+        if (SSL_set0_verify_cert_store(ssl_conn, ca_store) == 0) {
+            *err = "SSL_set0_verify_cert_store() failed";
+            goto failed;
+        }
+
         SSL_set_client_CA_list(ssl_conn, name_chain);
     }
 
     return NGX_OK;
 
 failed:
+
+    X509_STORE_free(ca_store);
 
     sk_X509_NAME_free(name_chain);
 

--- a/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
+++ b/src/subsys/ngx_subsys_lua_ssl_certby.c.tt2
@@ -1353,7 +1353,7 @@ failed:
 
 
 static int
-ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+ngx_[%s subsys %]_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 {
     /*
      * we never terminate handshake here and user can later use
@@ -1415,7 +1415,8 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
 
     /* enable verify */
 
-    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER,
+                   ngx_[%s subsys %]_lua_ssl_verify_callback);
 
     /* set depth */
 
@@ -1429,11 +1430,13 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
 [% END %]
         if (sscf != NULL) {
             depth = sscf->verify_depth;
+
         } else {
             /* same as the default value of ssl_verify_depth */
             depth = 1;
         }
     }
+
     SSL_set_verify_depth(ssl_conn, depth);
 
     if (chain != NULL) {
@@ -1490,9 +1493,9 @@ ngx_[% subsys %]_lua_ffi_ssl_verify_client([% req_type %] *r,
 
 failed:
 
-    X509_STORE_free(ca_store);
-
     sk_X509_NAME_free(name_chain);
+
+    X509_STORE_free(ca_store);
 
     return NGX_ERROR;
 }


### PR DESCRIPTION
This PR adds a FFI interface that allows users to configure SSL client certificate verification dynamically. For example, Nginx can now read SNI first and then determine whether to request a client certificate during handshake. Optionally, caller can pass in a CA list used for verification.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.