### PR TITLE
bugfix: hide get_request API in stream subsystem

### DIFF
--- a/src/subsys/api/ngx_subsys_lua_api.h.tt2
+++ b/src/subsys/api/ngx_subsys_lua_api.h.tt2
@@ -52,7 +52,9 @@ typedef struct {
 
 lua_State *ngx_[% subsys %]_lua_get_global_state(ngx_conf_t *cf);
 
+[% IF http_subsys %]
 [% req_type %] *ngx_[% subsys %]_lua_get_request(lua_State *L);
+[% END %]
 
 ngx_int_t ngx_[% subsys %]_lua_add_package_preload(ngx_conf_t *cf,
     const char *package, lua_CFunction func);

--- a/src/subsys/ngx_subsys_lua_api.c.tt2
+++ b/src/subsys/ngx_subsys_lua_api.c.tt2
@@ -27,11 +27,13 @@ ngx_[% subsys %]_lua_get_global_state(ngx_conf_t *cf)
 }
 
 
+[% IF http_subsys %]
 [% req_type %] *
 ngx_[% subsys %]_lua_get_request(lua_State *L)
 {
     return ngx_[% subsys %]_lua_get_req(L);
 }
+[% END %]
 
 
 static ngx_int_t ngx_[% subsys %]_lua_shared_memory_init(ngx_shm_zone_t *shm_zone,


### PR DESCRIPTION
As the req_type in stream subsystem is unexported.
Fix https://github.com/openresty/stream-lua-nginx-module/issues/180.