### PR TITLE
bugfix: ignore the `raw` argument when acquiring UDP request socket.

### DIFF
--- a/src/subsys/ngx_subsys_lua_socket_udp.c.tt2
+++ b/src/subsys/ngx_subsys_lua_socket_udp.c.tt2
@@ -1754,6 +1754,7 @@ ngx_[% subsys %]_lua_udp_socket_cleanup(void *data)
 int
 ngx_stream_lua_req_socket_udp(lua_State *L)
 {
+    int                                             n;
     ngx_stream_lua_udp_connection_t                *pc;
     ngx_stream_lua_srv_conf_t                      *lscf;
     ngx_connection_t                               *c;
@@ -1764,6 +1765,17 @@ ngx_stream_lua_req_socket_udp(lua_State *L)
     ngx_stream_lua_co_ctx_t                        *coctx;
 
     ngx_stream_lua_socket_udp_upstream_t           *u;
+
+    n = lua_gettop(L);
+
+    if (n != 0 && n != 1) {
+        return luaL_error(L, "expecting zero arguments, but got %d",
+                          lua_gettop(L));
+    }
+
+    if (n == 1) {
+        lua_pop(L, 1);
+    }
 
     r = ngx_stream_lua_get_req(L);
 


### PR DESCRIPTION
In the documentation, we stated that the `raw` argument of the
`ngx.req.socket` API is always ignored in the stream subsystem and we
does so for TCP request sockets. However, that's not the case for UDP
downstream socket. If the user specifies the `raw` argument manually a
LuaJIT assertion error like this would occur:

```
lj_api.c:1000: lua_rawseti: Assertion `(((uint32_t)((index2adr(L, idx))->it64 >> 47)) == (~11u))' failed.
```

Here are the crash dumps:

```
(gdb) bt
    at ../ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c:835
```

this PR makes sure the `raw` argument is properly ignored as we have
stated in the documentation and maintains the same behavior between TCP
and UDP sessions.