### PR TITLE
bugfix: sync stream-lua-nginx-module with three bugs.

### DIFF
--- a/src/subsys/ngx_subsys_lua_socket_udp.c.tt2
+++ b/src/subsys/ngx_subsys_lua_socket_udp.c.tt2
@@ -66,6 +66,10 @@ static int ngx_[% subsys %]_lua_socket_udp_close(lua_State *L);
 static ngx_int_t ngx_[% subsys %]_lua_socket_udp_resume([% req_type %] *r);
 static void ngx_[% subsys %]_lua_udp_resolve_cleanup(void *data);
 static void ngx_[% subsys %]_lua_udp_socket_cleanup(void *data);
+[% IF stream_subsys %]
+static ssize_t ngx_[% subsys %]_lua_udp_sendmsg(ngx_connection_t *c,
+    ngx_iovec_t *vec);
+[% END %]
 
 
 enum {
@@ -823,6 +827,10 @@ ngx_[% subsys %]_lua_socket_udp_send(lua_State *L)
     int                                  type;
     const char                          *msg;
     ngx_str_t                            query;
+[% IF stream_subsys %]
+    ngx_iovec_t                          vec;
+    struct iovec                         iovs[1];
+[% END %]
 
     ngx_[% subsys %]_lua_socket_udp_upstream_t  *u;
     ngx_[% subsys %]_lua_loc_conf_t             *llcf;
@@ -958,15 +966,24 @@ ngx_[% subsys %]_lua_socket_udp_send(lua_State *L)
 
     dd("sending query %.*s", (int) query.len, query.data);
 
+[% IF stream_subsys %]
+    vec.iovs = iovs;
+    vec.nalloc = 1;
+    vec.count = 1;
+    iovs[0].iov_base = query.data;
+    iovs[0].iov_len = query.len;
+    vec.size = query.len;
+[% END %]
 [% IF http_subsys %]
     n = ngx_send(u->udp_connection.connection, query.data, query.len);
 
     dd("ngx_send returns %d (query len %d)", (int) n, (int) query.len);
 
 [% ELSIF stream_subsys %]
-    n = ngx_udp_send(u->udp_connection.connection, query.data, query.len);
+    n = ngx_stream_lua_udp_sendmsg(u->udp_connection.connection, &vec);
 
-    dd("ngx_udp_send returns %d (query len %d)", (int) n, (int) query.len);
+    dd("ngx_stream_lua_udp_sendmsg returns %d (query len %d)",
+       (int) n, (int) query.len);
 [% END %]
 
     if (n == NGX_ERROR || n == NGX_AGAIN) {
@@ -1871,7 +1888,145 @@ ngx_stream_lua_req_socket_udp(lua_State *L)
     lua_settop(L, 1);
     return 1;
 }
-[% END %]
 
+
+static ssize_t
+ngx_[% subsys %]_lua_udp_sendmsg(ngx_connection_t *c, ngx_iovec_t *vec)
+{
+    ssize_t        n;
+    ngx_err_t      err;
+    struct msghdr  msg;
+
+#if (NGX_HAVE_MSGHDR_MSG_CONTROL)
+
+#if (NGX_HAVE_IP_SENDSRCADDR)
+    u_char         msg_control[CMSG_SPACE(sizeof(struct in_addr))];
+#elif (NGX_HAVE_IP_PKTINFO)
+    u_char         msg_control[CMSG_SPACE(sizeof(struct in_pktinfo))];
+#endif
+
+#if (NGX_HAVE_INET6 && NGX_HAVE_IPV6_RECVPKTINFO)
+    u_char         msg_control6[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+#endif
+
+#endif
+
+    ngx_memzero(&msg, sizeof(struct msghdr));
+
+    if (c->socklen) {
+        msg.msg_name = c->sockaddr;
+        msg.msg_namelen = c->socklen;
+    }
+
+    msg.msg_iov = vec->iovs;
+    msg.msg_iovlen = vec->count;
+
+#if (NGX_HAVE_MSGHDR_MSG_CONTROL)
+
+    if (c->listening && c->listening->wildcard && c->local_sockaddr) {
+
+#if (NGX_HAVE_IP_SENDSRCADDR)
+
+        if (c->local_sockaddr->sa_family == AF_INET) {
+            struct cmsghdr      *cmsg;
+            struct in_addr      *addr;
+            struct sockaddr_in  *sin;
+
+            msg.msg_control = &msg_control;
+            msg.msg_controllen = sizeof(msg_control);
+
+            cmsg = CMSG_FIRSTHDR(&msg);
+            cmsg->cmsg_level = IPPROTO_IP;
+            cmsg->cmsg_type = IP_SENDSRCADDR;
+            cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_addr));
+
+            sin = (struct sockaddr_in *) c->local_sockaddr;
+
+            addr = (struct in_addr *) CMSG_DATA(cmsg);
+            *addr = sin->sin_addr;
+        }
+
+#elif (NGX_HAVE_IP_PKTINFO)
+
+        if (c->local_sockaddr->sa_family == AF_INET) {
+            struct cmsghdr      *cmsg;
+            struct in_pktinfo   *pkt;
+            struct sockaddr_in  *sin;
+
+            msg.msg_control = &msg_control;
+            msg.msg_controllen = sizeof(msg_control);
+
+            cmsg = CMSG_FIRSTHDR(&msg);
+            cmsg->cmsg_level = IPPROTO_IP;
+            cmsg->cmsg_type = IP_PKTINFO;
+            cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
+
+            sin = (struct sockaddr_in *) c->local_sockaddr;
+
+            pkt = (struct in_pktinfo *) CMSG_DATA(cmsg);
+            ngx_memzero(pkt, sizeof(struct in_pktinfo));
+            pkt->ipi_spec_dst = sin->sin_addr;
+        }
+
+#endif
+
+#if (NGX_HAVE_INET6 && NGX_HAVE_IPV6_RECVPKTINFO)
+
+        if (c->local_sockaddr->sa_family == AF_INET6) {
+            struct cmsghdr       *cmsg;
+            struct in6_pktinfo   *pkt6;
+            struct sockaddr_in6  *sin6;
+
+            msg.msg_control = &msg_control6;
+            msg.msg_controllen = sizeof(msg_control6);
+
+            cmsg = CMSG_FIRSTHDR(&msg);
+            cmsg->cmsg_level = IPPROTO_IPV6;
+            cmsg->cmsg_type = IPV6_PKTINFO;
+            cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
+
+            sin6 = (struct sockaddr_in6 *) c->local_sockaddr;
+
+            pkt6 = (struct in6_pktinfo *) CMSG_DATA(cmsg);
+            ngx_memzero(pkt6, sizeof(struct in6_pktinfo));
+            pkt6->ipi6_addr = sin6->sin6_addr;
+        }
+
+#endif
+    }
+
+#endif
+
+eintr:
+
+    n = sendmsg(c->fd, &msg, 0);
+
+    ngx_log_debug4(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "sendto: fd:%d %z of %uz to \"%V\"",
+                   c->fd, n, vec->size, &c->addr_text);
+    if (n == -1) {
+        err = ngx_errno;
+
+        switch (err) {
+        case NGX_EAGAIN:
+            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, err,
+                           "sendmsg() not ready");
+            return NGX_AGAIN;
+
+        case NGX_EINTR:
+            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, err,
+                           "sendmsg() was interrupted");
+            goto eintr;
+
+        default:
+            c->write->error = 1;
+            ngx_connection_error(c, err, "sendmsg() failed");
+            return NGX_ERROR;
+        }
+    }
+
+    return n;
+}
+[% END %]
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/subsys/ngx_subsys_lua_timer.c.tt2
+++ b/src/subsys/ngx_subsys_lua_timer.c.tt2
@@ -828,16 +828,19 @@ ngx_[% subsys %]_lua_log_timer_error(ngx_log_t *log, u_char *buf, size_t len)
     len -= p - buf;
     buf = p;
 
-    if (c->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
-        len -= p - buf;
-        buf = p;
-    }
+    if (c != NULL) {
+        if (c->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+            len -= p - buf;
+            buf = p;
+        }
 
-    if (c && c->listening && c->listening->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
-        /* len -= p - buf; */
-        buf = p;
+        if (c->listening && c->listening->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", server: %V",
+                             &c->listening->addr_text);
+            /* len -= p - buf; */
+            buf = p;
+        }
     }
 
     return buf;

--- a/src/subsys/ngx_subsys_lua_util.c.tt2
+++ b/src/subsys/ngx_subsys_lua_util.c.tt2
@@ -1455,8 +1455,9 @@ user_co_done:
                 break;
 
             case LUA_ERRMEM:
-                err = "memory allocation error";
-                ngx_quit = 1;
+                err = "[lua] memory allocation error";
+                ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0, err);
+                abort();
                 break;
 
             case LUA_ERRERR:


### PR DESCRIPTION
    bugfix:  wrong source address for the replying packet when received udp packet via req.socket  on se
    condary address.
   bugfix: fix possible null pointer dereference found by Coverity.

change: changed from graceful shutdown to abort when lua_resume return LUA_ERRMEM.